### PR TITLE
Fix an invalid service port name.

### DIFF
--- a/charts/gotosocial/templates/service.yaml
+++ b/charts/gotosocial/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: gotosocial
+      targetPort: http
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
As an port name in Deployment was changed in the version 0.4.24.
refs 0hlov3/charts#10 (This patch is an additional fix.)
refs fc3c35639f98f9373a71e18d34bdf5bc02545fbf

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
