### PR TITLE
gotosocial: Allow existingClaim for persistent volume

### DIFF
--- a/charts/gotosocial/Chart.yaml
+++ b/charts/gotosocial/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/superseriousbusiness/gotosocial
 
 type: application
 # Chart Version
-version: "0.4.28"
+version: "0.5.0"
 # gotosocial version
 appVersion: "0.17.3"
 

--- a/charts/gotosocial/templates/_helpers.tpl
+++ b/charts/gotosocial/templates/_helpers.tpl
@@ -76,3 +76,14 @@ Set postgres host
 {{- template "gotosocial.postgresql.fullname" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create Volumeclaim Name
+*/}}
+{{- define "gotosocial.volume.claimName" -}}
+{{- if and .Values.gotosocial.persistence.enabled (ne .Values.gotosocial.persistence.existingClaim "") -}}
+{{ .Values.gotosocial.persistence.existingClaim }}
+{{- else -}}
+{{ printf "%s-%s" (include "gotosocial.fullname" .) "data" }}
+{{- end -}}
+{{- end -}}

--- a/charts/gotosocial/templates/deployment.yaml
+++ b/charts/gotosocial/templates/deployment.yaml
@@ -133,7 +133,11 @@ spec:
         {{- if .Values.gotosocial.persistence.enabled }}
         - name: gotosocial-data
           persistentVolumeClaim:
+            {{- if .Values.gotosocial.persistence.existingClaim }}
+            claimName: {{ .Values.gotosocial.persistence.existingClaim }}
+            {{- else }}
             claimName: {{ $fullName }}-data
+            {{- end }}
         {{- end }}
         {{- if .Values.gotosocial.tmpfs.enabled }}
         - name: tmpfs

--- a/charts/gotosocial/templates/deployment.yaml
+++ b/charts/gotosocial/templates/deployment.yaml
@@ -133,11 +133,7 @@ spec:
         {{- if .Values.gotosocial.persistence.enabled }}
         - name: gotosocial-data
           persistentVolumeClaim:
-            {{- if .Values.gotosocial.persistence.existingClaim }}
-            claimName: {{ .Values.gotosocial.persistence.existingClaim }}
-            {{- else }}
-            claimName: {{ $fullName }}-data
-            {{- end }}
+            claimName: {{ include "gotosocial.volume.claimName" . }}
         {{- end }}
         {{- if .Values.gotosocial.tmpfs.enabled }}
         - name: tmpfs

--- a/charts/gotosocial/templates/pvc.yaml
+++ b/charts/gotosocial/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gotosocial.persistence.enabled }}
+{{- if and .Values.gotosocial.persistence.enabled (eq .Values.gotosocial.persistence.existingClaim "") -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/gotosocial/values.yaml
+++ b/charts/gotosocial/values.yaml
@@ -47,6 +47,8 @@ gotosocial:
     accessMode: "ReadWriteOnce"
     size: "10Gi"
     #storageClass: ""
+    # use an existing persistent volume claim
+    existingClaim: ""
   tmpfs:
     enabled: false
     size: "1Gi"
@@ -188,7 +190,7 @@ podSecurityContext:
 
 securityContext:
   capabilities:
-    drop: 
+    drop:
       - ALL
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false


### PR DESCRIPTION
This just allows a user to optionally provide an existing persistent volume claim for the `gotosocial.persistence.existingClaim` parameter.