### PR TITLE
[joplin-server] Refactor chart to v1.0.0 — drop Bitnami dep, add SQLite/storage/schema

### DIFF
--- a/charts/joplin-server/Chart.yaml
+++ b/charts/joplin-server/Chart.yaml
@@ -9,14 +9,10 @@ maintainers:
     email: dev@privatetrace.io
     url: https://schoenwald.aero
 
+kubeVersion: ">=1.23.0-0"
 type: application
 # ChartVersion
-version: "0.2.9"
+version: "1.0.0"
 # AppVersion
-appVersion: "2.14.1-beta"
+appVersion: "3.6.1"
 
-dependencies:
-  - name: postgresql
-    version: ~11.9.13
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled

--- a/charts/joplin-server/README.md
+++ b/charts/joplin-server/README.md
@@ -108,6 +108,7 @@ joplin:
 
 persistence:
   enabled: true
+  mountPath: /data
   size: 10Gi
 ```
 

--- a/charts/joplin-server/README.md
+++ b/charts/joplin-server/README.md
@@ -1,34 +1,253 @@
 # Joplin Server Chart
 
+> **Breaking change:** Chart >= 1.0.0 is **not compatible** with upgrades from earlier versions.
+> The Bitnami PostgreSQL sub-chart has been removed and the values schema was restructured.
+> See the migration note below before proceeding.
+
 ## Add the Chart
+
 ```shell
 helm repo add schoenwald https://charts.schoenwald.aero
 helm repo update schoenwald
 ```
 
-## Show version
+## Show versions
+
 ```shell
 helm search repo schoenwald/joplin-server
 ```
 
+## Database backends
+
+| `joplin.database.client` | Use case |
+|---|---|
+| `sqlite` (default) | Testing, development, single-user |
+| `pg` | Production, multi-user |
+
+### SQLite (default)
+
+No extra configuration needed. The database file lives at `/home/joplin/.config/joplin-server/` inside the container — enable persistence so it survives pod restarts:
+
+```yaml
+persistence:
+  enabled: true
+  mountPath: /home/joplin/.config/joplin-server
+  size: 2Gi
+```
+
+> **Note:** SQLite is not suitable for production or multi-user deployments.
+
+### PostgreSQL
+
+Provision PostgreSQL externally, set `joplin.database.client: pg`, and supply the credentials via `joplin.postgres.*` or a Kubernetes Secret.
+
 ## Create Namespace
+
 ```shell
 kubectl create namespace joplin --dry-run=client -o yaml | kubectl apply -f -
 ```
-## Create Mail Secret
-Create Mail Secret if `.Values.joplin.mailer.enabled` is set to `true`
-```shell
-k create secret generic joplin-mailer \
---from-literal=mailerAuthPassword='' \
---from-literal=mailerHost='' \
---from-literal=mailerport='' \
---from-literal=mailerSecure='' \
---from-literal=mailerAuthUser='' \
---from-literal=mailerNoreplyName='' \
---from-literal=mailerNoreplyEmail='' 
+
+## Configure PostgreSQL credentials
+
+### Option A — plain values (not recommended for production)
+
+```yaml
+joplin:
+  postgres:
+    host: my-postgres.example.com
+    port: 5432
+    database: joplin-server
+    user: joplin
+    password: supersecret
 ```
 
-### Deploy
+### Option B — existing Secret (recommended)
+
 ```shell
-helm upgrade --install joplin schoenwald/joplin-server --namespace joplin --create-namespace
+kubectl create secret generic joplin-postgres \
+  --namespace joplin \
+  --from-literal=password='supersecret'
 ```
+
+```yaml
+joplin:
+  postgres:
+    host: my-postgres.example.com
+    database: joplin-server
+    user: joplin
+    existingSecret: joplin-postgres
+    existingSecretPasswordKey: password
+```
+
+## Configure Mailer (optional)
+
+Create the Secret when `.Values.joplin.mailer.enabled` is `true`.
+All keys must be present even if empty.
+
+```shell
+kubectl create secret generic joplin-mailer \
+  --namespace joplin \
+  --from-literal=mailerHost='' \
+  --from-literal=mailerPort='' \
+  --from-literal=mailerSecure='' \
+  --from-literal=mailerAuthUser='' \
+  --from-literal=mailerAuthPassword='' \
+  --from-literal=mailerNoreplyName='' \
+  --from-literal=mailerNoreplyEmail=''
+```
+
+## Configure Storage (optional)
+
+The default storage driver keeps all data in PostgreSQL (`Type=Database`).
+To use filesystem storage, enable persistence and point the driver at the mount path:
+
+```yaml
+joplin:
+  storage:
+    driver: "Type=Filesystem; Path=/data"
+
+persistence:
+  enabled: true
+  size: 10Gi
+```
+
+For S3:
+
+```yaml
+joplin:
+  storage:
+    driver: "Type=S3; Region=us-east-1; AccessKeyId=…; SecretAccessKeyId=…; Bucket=my-bucket"
+```
+
+## Deploy
+
+```shell
+helm upgrade --install joplin schoenwald/joplin-server \
+  --namespace joplin \
+  --create-namespace \
+  -f my-values.yaml
+```
+
+## Migration from chart < 1.0.0
+
+1. **Back up your data** — dump the PostgreSQL database managed by the old Bitnami sub-chart.
+2. Restore the dump into your external PostgreSQL instance.
+3. Uninstall the old release: `helm uninstall joplin -n joplin`
+4. Deploy fresh with the new values schema shown above.
+
+There is no in-place upgrade path between chart versions `< 1.0.0` and `>= 1.0.0`.
+
+## Parameters
+
+### Global parameters
+
+| Name           | Description                      | Value |
+| -------------- | -------------------------------- | ----- |
+| `replicaCount` | Number of Joplin Server replicas | `1`   |
+
+### Image parameters
+
+| Name               | Description                                         | Value           |
+| ------------------ | --------------------------------------------------- | --------------- |
+| `image.repository` | Docker image repository                             | `joplin/server` |
+| `image.pullPolicy` | Image pull policy                                   | `IfNotPresent`  |
+| `image.tag`        | Image tag (overrides the chart appVersion when set) | `""`            |
+| `imagePullSecrets` | List of image pull secret names                     | `[]`            |
+| `nameOverride`     | Override for the chart name                         | `""`            |
+| `fullnameOverride` | Override for the full release name                  | `""`            |
+
+### Joplin parameters
+
+| Name                                        | Description                                                                                                                                                        | Value                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `joplin.appBaseUrl`                         | Publicly reachable base URL of the server (e.g. https://joplin.example.com)                                                                                        | `http://localhost:22300` |
+| `joplin.appPort`                            | Port the Joplin Server process listens on inside the container                                                                                                     | `22300`                  |
+| `joplin.database.client`                    | Database backend. `sqlite` for testing/single-user; `pg` for production                                                                                            | `sqlite`                 |
+| `joplin.postgres.host`                      | PostgreSQL host                                                                                                                                                    | `localhost`              |
+| `joplin.postgres.port`                      | PostgreSQL port                                                                                                                                                    | `5432`                   |
+| `joplin.postgres.database`                  | PostgreSQL database name                                                                                                                                           | `joplin-server`          |
+| `joplin.postgres.user`                      | PostgreSQL username                                                                                                                                                | `joplin`                 |
+| `joplin.postgres.password`                  | Plain-text PostgreSQL password. Ignored when existingSecret is set. Do NOT use in production.                                                                      | `""`                     |
+| `joplin.postgres.existingSecret`            | Name of an existing Secret containing the PostgreSQL password                                                                                                      | `""`                     |
+| `joplin.postgres.existingSecretPasswordKey` | Key inside the Secret that holds the PostgreSQL password                                                                                                           | `password`               |
+| `joplin.postgres.sslModeNoVerify`           | Connect via POSTGRES_CONNECTION_STRING with ?sslmode=no-verify appended                                                                                            | `false`                  |
+| `joplin.storage.driver`                     | STORAGE_DRIVER passed verbatim to Joplin Server. Examples: `Type=Database`, `Type=Filesystem; Path=/data`, `Type=S3; Region=…`                                     | `Type=Database`          |
+| `joplin.storage.driverFallback`             | Optional STORAGE_DRIVER_FALLBACK value for migration scenarios                                                                                                     | `""`                     |
+| `joplin.mailer.enabled`                     | Enable mailer support. Requires an existing Secret named by joplin.mailer.existingSecretName                                                                       | `false`                  |
+| `joplin.mailer.existingSecretName`          | Name of the Secret with mailer credentials (keys: mailerHost, mailerPort, mailerSecure, mailerAuthUser, mailerAuthPassword, mailerNoreplyName, mailerNoreplyEmail) | `joplin-mailer`          |
+
+### Persistence parameters
+
+| Name                        | Description                                                                     | Value                                |
+| --------------------------- | ------------------------------------------------------------------------------- | ------------------------------------ |
+| `persistence.enabled`       | Enable persistent storage. Required for SQLite and Filesystem storage backends. | `false`                              |
+| `persistence.mountPath`     | Mount path inside the container                                                 | `/home/joplin/.config/joplin-server` |
+| `persistence.storageClass`  | StorageClass for the PVC. Leave empty to use the cluster default.               | `""`                                 |
+| `persistence.accessMode`    | PVC access mode                                                                 | `ReadWriteOnce`                      |
+| `persistence.size`          | PVC size                                                                        | `1Gi`                                |
+| `persistence.existingClaim` | Name of an existing PVC to use instead of creating one                          | `""`                                 |
+
+### Service Account parameters
+
+| Name                         | Description                                                                              | Value  |
+| ---------------------------- | ---------------------------------------------------------------------------------------- | ------ |
+| `serviceAccount.create`      | Create a ServiceAccount for the pod                                                      | `true` |
+| `serviceAccount.annotations` | Annotations to add to the ServiceAccount                                                 | `{}`   |
+| `serviceAccount.name`        | Name of the ServiceAccount. Auto-generated when empty and serviceAccount.create is true. | `""`   |
+
+### Pod parameters
+
+| Name                                     | Description                                      | Value   |
+| ---------------------------------------- | ------------------------------------------------ | ------- |
+| `podAnnotations`                         | Annotations to add to the pod                    | `{}`    |
+| `podSecurityContext.fsGroup`             | Group ID for the pod filesystem                  | `1001`  |
+| `securityContext.capabilities.drop`      | Capabilities to drop from the container          | `[]`    |
+| `securityContext.readOnlyRootFilesystem` | Mount the container root filesystem as read-only | `false` |
+| `securityContext.runAsNonRoot`           | Require the container to run as a non-root user  | `true`  |
+| `securityContext.runAsUser`              | User ID to run the container process             | `1001`  |
+| `securityContext.runAsGroup`             | Group ID to run the container process            | `1001`  |
+
+### Service parameters
+
+| Name           | Description             | Value       |
+| -------------- | ----------------------- | ----------- |
+| `service.type` | Kubernetes Service type | `ClusterIP` |
+| `service.port` | Service port            | `80`        |
+
+### Ingress parameters
+
+| Name                                 | Description                                       | Value                    |
+| ------------------------------------ | ------------------------------------------------- | ------------------------ |
+| `ingress.enabled`                    | Enable Ingress                                    | `false`                  |
+| `ingress.className`                  | IngressClass name (e.g. nginx)                    | `nginx`                  |
+| `ingress.annotations`                | Additional annotations for the Ingress            | `{}`                     |
+| `ingress.hosts[0].host`              | Hostname for the Ingress rule                     | `chart-example.local`    |
+| `ingress.hosts[0].paths[0].path`     | URL path                                          | `/`                      |
+| `ingress.hosts[0].paths[0].pathType` | Path type (Exact, Prefix, ImplementationSpecific) | `ImplementationSpecific` |
+| `ingress.tls`                        | TLS configuration for the Ingress                 | `[]`                     |
+
+### Resource parameters
+
+| Name                        | Description    | Value   |
+| --------------------------- | -------------- | ------- |
+| `resources.limits.memory`   | Memory limit   | `512Mi` |
+| `resources.limits.cpu`      | CPU limit      | `500m`  |
+| `resources.requests.memory` | Memory request | `256Mi` |
+| `resources.requests.cpu`    | CPU request    | `100m`  |
+
+### Autoscaling parameters
+
+| Name                                         | Description                       | Value   |
+| -------------------------------------------- | --------------------------------- | ------- |
+| `autoscaling.enabled`                        | Enable Horizontal Pod Autoscaler  | `false` |
+| `autoscaling.minReplicas`                    | Minimum number of replicas        | `1`     |
+| `autoscaling.maxReplicas`                    | Maximum number of replicas        | `5`     |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage | `80`    |
+
+### Scheduling parameters
+
+| Name           | Description                       | Value |
+| -------------- | --------------------------------- | ----- |
+| `nodeSelector` | Node labels for pod assignment    | `{}`  |
+| `tolerations`  | Tolerations for pod assignment    | `[]`  |
+| `affinity`     | Affinity rules for pod assignment | `{}`  |

--- a/charts/joplin-server/examples/values-production.yaml
+++ b/charts/joplin-server/examples/values-production.yaml
@@ -1,0 +1,37 @@
+joplin:
+  appBaseUrl: https://notes.privatetrace.io
+
+  database:
+    client: pg
+
+  postgres:
+    host: shared-database-rw.shared-database.svc.cluster.local
+    port: 5432
+    database: joplin-server
+    user: joplin
+    existingSecret: joplin-database
+    existingSecretPasswordKey: password
+
+  storage:
+    driver: "Type=Filesystem; Path=/data"
+
+persistence:
+  enabled: true
+  mountPath: /data
+  accessMode: ReadWriteOnce
+  size: 2Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: notes.privatetrace.io
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: joplin-tls
+      hosts:
+        - notes.privatetrace.io

--- a/charts/joplin-server/templates/NOTES.txt
+++ b/charts/joplin-server/templates/NOTES.txt
@@ -1,3 +1,23 @@
+################################################################################
+##                        BREAKING CHANGE — READ CAREFULLY                    ##
+################################################################################
+
+This chart (>= 1.0.0) is NOT compatible with upgrades from earlier versions.
+
+What changed:
+  - The Bitnami PostgreSQL sub-chart has been removed entirely.
+    You must provision PostgreSQL externally and configure
+    joplin.postgres.* (or joplin.postgres.existingSecret) before deploying.
+  - Values keys were restructured — old values.yaml files will NOT work.
+    Refer to the chart README for the new schema.
+
+If you are migrating from a previous release:
+  1. Back up your PostgreSQL data.
+  2. Uninstall the old release (helm uninstall <release>).
+  3. Deploy fresh with the new values schema.
+
+################################################################################
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -10,13 +30,29 @@
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "joplin-server.fullname" . }}'
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch with: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "joplin-server.fullname" . }}
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "joplin-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+{{- else }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "joplin-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.joplin.appPort }}
+{{- end }}
+
+2. Default admin credentials (change immediately after first login):
+   Email:    admin@localhost
+   Password: admin
+
+{{- if eq .Values.joplin.database.client "sqlite" }}
+
+WARNING: SQLite is enabled. The database file is stored inside the container
+and will be lost when the pod restarts unless you enable persistence:
+
+  persistence:
+    enabled: true
+    mountPath: /home/joplin/.config/joplin-server
+
+SQLite is not recommended for production or multi-user deployments.
+Use joplin.database.client=pg with an external PostgreSQL instance instead.
 {{- end }}

--- a/charts/joplin-server/templates/_helpers.tpl
+++ b/charts/joplin-server/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+If the release name already contains the chart name it is used as-is.
 */}}
 {{- define "joplin-server.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -62,17 +62,12 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Name of the PVC to mount for filesystem storage.
 */}}
-{{- define "joplin-server.postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{/*
-Set postgres host
-*/}}
-{{- define "joplin-server.postgresql.host" -}}
-{{- if .Values.postgresql.enabled -}}
-{{- template "joplin-server.postgresql.fullname" . -}}
-{{- end -}}
-{{- end -}}
+{{- define "joplin-server.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- include "joplin-server.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/joplin-server/templates/deployment.yaml
+++ b/charts/joplin-server/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- $postgresHost := include "joplin-server.postgresql.host" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,12 +35,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: APP_BASE_URL
-              value: "{{ .Values.joplin.APP_BASE_URL }}"
+              value: {{ .Values.joplin.appBaseUrl | quote }}
             - name: APP_PORT
-              value: {{ .Values.joplin.APP_PORT |quote }}
+              value: {{ .Values.joplin.appPort | quote }}
+            - name: STORAGE_DRIVER
+              value: {{ .Values.joplin.storage.driver | quote }}
+            {{- if .Values.joplin.storage.driverFallback }}
+            - name: STORAGE_DRIVER_FALLBACK
+              value: {{ .Values.joplin.storage.driverFallback | quote }}
+            {{- end }}
             {{- if .Values.joplin.mailer.enabled }}
             - name: MAILER_ENABLED
-              value: "{{ .Values.joplin.mailer.enabled }}"
+              value: "1"
             - name: MAILER_HOST
               valueFrom:
                 secretKeyRef:
@@ -51,7 +56,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.joplin.mailer.existingSecretName }}
-                  key: mailerport
+                  key: mailerPort
             - name: MAILER_SECURE
               valueFrom:
                 secretKeyRef:
@@ -78,60 +83,66 @@ spec:
                   name: {{ .Values.joplin.mailer.existingSecretName }}
                   key: mailerNoreplyEmail
             {{- end }}
-            {{- if and (eq .Values.joplin.externalPostgres.enabled true) (eq .Values.joplin.externalPostgres.POSTGRES_SSL_MODE_NO_VERIFY false) }}
+            {{- if eq .Values.joplin.database.client "pg" }}
             - name: DB_CLIENT
               value: "pg"
-            - name: POSTGRES_PASSWORD
-              value: "{{ .Values.joplin.externalPostgres.POSTGRES_PASSWORD }}"
-            - name: POSTGRES_DATABASE
-              value: "{{ .Values.joplin.externalPostgres.POSTGRES_DATABASE }}"
-            - name: POSTGRES_USER
-              value: "{{ .Values.joplin.externalPostgres.POSTGRES_USER }}"
-            - name: POSTGRES_PORT
-              value: "{{ .Values.joplin.externalPostgres.POSTGRES_PORT }}"
-            - name: POSTGRES_HOST
-              value: "{{ .Values.joplin.externalPostgres.POSTGRES_HOST }}"
-            {{ else if and (eq .Values.joplin.externalPostgres.enabled true) (eq .Values.joplin.externalPostgres.POSTGRES_SSL_MODE_NO_VERIFY true) }}
-            - name: DB_CLIENT
-              value: "pg"
-            - name: POSTGRES_CONNECTION_STRING
-              value: "postgresql://{{ .Values.joplin.externalPostgres.POSTGRES_USER }}:{{ .Values.joplin.externalPostgres.POSTGRES_PASSWORD }}@{{ .Values.joplin.externalPostgres.POSTGRES_HOST }}:{{ .Values.joplin.externalPostgres.POSTGRES_PORT }}/{{ .Values.joplin.externalPostgres.POSTGRES_DATABASE }}?sslmode=no-verify"
-            {{- else if .Values.postgresql.enabled }}
-            - name: DB_CLIENT
-              value: "pg"
-            - name: POSTGRES_DATABASE
-              value: "{{ .Values.postgresql.auth.database }}"
-            - name: POSTGRES_USER
-              value: "{{ .Values.postgresql.auth.username }}"
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_HOST
-              value: "{{ $postgresHost }}"
-            {{- if .Values.postgresql.auth.existingSecret }}
+            {{- if .Values.joplin.postgres.existingSecret }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: password
-                  name: "{{ .Values.postgresql.auth.existingSecret }}"
+                  name: {{ .Values.joplin.postgres.existingSecret }}
+                  key: {{ .Values.joplin.postgres.existingSecretPasswordKey }}
             {{- else }}
             - name: POSTGRES_PASSWORD
-              value: "{{ .Values.postgresql.auth.password }}"
+              value: {{ .Values.joplin.postgres.password | quote }}
+            {{- end }}
+            {{- if .Values.joplin.postgres.sslModeNoVerify }}
+            - name: POSTGRES_CONNECTION_STRING
+              value: "postgresql://{{ .Values.joplin.postgres.user }}:$(POSTGRES_PASSWORD)@{{ .Values.joplin.postgres.host }}:{{ .Values.joplin.postgres.port }}/{{ .Values.joplin.postgres.database }}?sslmode=no-verify"
+            {{- else }}
+            - name: POSTGRES_HOST
+              value: {{ .Values.joplin.postgres.host | quote }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.joplin.postgres.port | quote }}
+            - name: POSTGRES_DATABASE
+              value: {{ .Values.joplin.postgres.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.joplin.postgres.user | quote }}
             {{- end }}
             {{- end }}
           ports:
             - name: http
-              containerPort: 22300
+              containerPort: {{ .Values.joplin.appPort }}
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            httpGet:
+              path: /api/ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "joplin-server.pvcName" . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/joplin-server/templates/hpa.yaml
+++ b/charts/joplin-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "joplin-server.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/joplin-server/templates/ingress.yaml
+++ b/charts/joplin-server/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "joplin-server.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -43,19 +32,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/joplin-server/templates/pvc.yaml
+++ b/charts/joplin-server/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "joplin-server.fullname" . }}
+  labels:
+    {{- include "joplin-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/joplin-server/templates/tests/test-connection.yaml
+++ b/charts/joplin-server/templates/tests/test-connection.yaml
@@ -11,5 +11,8 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "joplin-server.fullname" . }}:{{ .Values.service.port }}']
+      args:
+        - '--spider'
+        - '--timeout=10'
+        - 'http://{{ include "joplin-server.fullname" . }}:{{ .Values.service.port }}/api/ping'
   restartPolicy: Never

--- a/charts/joplin-server/values.schema.json
+++ b/charts/joplin-server/values.schema.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "joplin-server values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": { "type": "string" }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "nameOverride":     { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "joplin": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "appBaseUrl": { "type": "string", "minLength": 1 },
+        "appPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "client": {
+              "type": "string",
+              "enum": ["sqlite", "pg"],
+              "description": "Database backend. Use 'sqlite' for testing/single-user, 'pg' for production."
+            }
+          },
+          "required": ["client"]
+        },
+        "postgres": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host":     { "type": "string", "minLength": 1 },
+            "port":     { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "database": { "type": "string", "minLength": 1 },
+            "user":     { "type": "string", "minLength": 1 },
+            "password": { "type": "string" },
+            "existingSecret":             { "type": "string" },
+            "existingSecretPasswordKey":  { "type": "string", "minLength": 1 },
+            "sslModeNoVerify": { "type": "boolean" }
+          },
+          "required": ["host", "port", "database", "user", "existingSecretPasswordKey"]
+        },
+        "storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "driver":         { "type": "string", "minLength": 1 },
+            "driverFallback": { "type": "string" }
+          },
+          "required": ["driver"]
+        },
+        "mailer": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled":            { "type": "boolean" },
+            "existingSecretName": { "type": "string", "minLength": 1 }
+          },
+          "required": ["enabled"],
+          "if":   { "properties": { "enabled": { "const": true } } },
+          "then": { "required": ["existingSecretName"] }
+        }
+      },
+      "required": ["appBaseUrl", "appPort", "database", "postgres", "storage", "mailer"]
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":       { "type": "boolean" },
+        "mountPath":     { "type": "string", "minLength": 1 },
+        "storageClass":  { "type": "string" },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany", "ReadWriteOncePod"]
+        },
+        "size":          { "type": "string", "minLength": 1 },
+        "existingClaim": { "type": "string" }
+      },
+      "required": ["enabled", "mountPath", "accessMode", "size"]
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create":      { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name":        { "type": "string" }
+      },
+      "required": ["create"]
+    },
+    "podAnnotations":    { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext":    { "type": "object" },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      },
+      "required": ["type", "port"]
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":     { "type": "boolean" },
+        "className":   { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path":     { "type": "string" },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    }
+                  },
+                  "required": ["path", "pathType"]
+                }
+              }
+            },
+            "required": ["host", "paths"]
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretName": { "type": "string" },
+              "hosts": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "required": ["secretName", "hosts"]
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limits":   {
+          "type": "object",
+          "properties": {
+            "cpu":    { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu":    { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":                        { "type": "boolean" },
+        "minReplicas":                    { "type": "integer", "minimum": 1 },
+        "maxReplicas":                    { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "targetMemoryUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 }
+      },
+      "required": ["enabled"],
+      "if":   { "properties": { "enabled": { "const": true } } },
+      "then": { "required": ["minReplicas", "maxReplicas"] }
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations":  { "type": "array" },
+    "affinity":     { "type": "object" }
+  },
+  "required": [
+    "replicaCount", "image", "joplin", "persistence",
+    "serviceAccount", "service", "ingress", "resources", "autoscaling"
+  ]
+}

--- a/charts/joplin-server/values.yaml
+++ b/charts/joplin-server/values.yaml
@@ -1,120 +1,187 @@
-# Default values for joplin-server.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+## @section Global parameters
 
+## @param replicaCount Number of Joplin Server replicas
 replicaCount: 1
 
+## @section Image parameters
+
+## @param image.repository Docker image repository
+## @param image.pullPolicy Image pull policy
+## @param image.tag [string] Image tag (overrides the chart appVersion when set)
 image:
   repository: joplin/server
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-joplin:
-  APP_PORT: 22300
-  APP_BASE_URL: http://localhost:22300
-  externalPostgres:
-    enabled: false
-    POSTGRES_PASSWORD: joplin
-    POSTGRES_DATABASE: joplin
-    POSTGRES_USER: joplin
-    POSTGRES_PORT: 5432
-    POSTGRES_HOST: localhost
-    POSTGRES_SSL_MODE_NO_VERIFY: false
-  mailer:
-    enabled: false
-    existingSecretName: joplin-mailer
-
-
+## @param imagePullSecrets [array] List of image pull secret names
 imagePullSecrets: []
+## @param nameOverride [string] Override for the chart name
 nameOverride: ""
+## @param fullnameOverride [string] Override for the full release name
 fullnameOverride: ""
 
+## @section Joplin parameters
+
+joplin:
+  ## @param joplin.appBaseUrl Publicly reachable base URL of the server (e.g. https://joplin.example.com)
+  appBaseUrl: http://localhost:22300
+  ## @param joplin.appPort Port the Joplin Server process listens on inside the container
+  appPort: 22300
+
+  ## Database backend configuration
+  database:
+    ## @param joplin.database.client Database backend. `sqlite` for testing/single-user; `pg` for production
+    client: sqlite
+
+  ## External PostgreSQL configuration (used when joplin.database.client=pg)
+  postgres:
+    ## @param joplin.postgres.host PostgreSQL host
+    host: localhost
+    ## @param joplin.postgres.port PostgreSQL port
+    port: 5432
+    ## @param joplin.postgres.database PostgreSQL database name
+    database: joplin-server
+    ## @param joplin.postgres.user PostgreSQL username
+    user: joplin
+    ## @param joplin.postgres.password [string] Plain-text PostgreSQL password. Ignored when existingSecret is set. Do NOT use in production.
+    password: ""
+    ## @param joplin.postgres.existingSecret [string] Name of an existing Secret containing the PostgreSQL password
+    existingSecret: ""
+    ## @param joplin.postgres.existingSecretPasswordKey Key inside the Secret that holds the PostgreSQL password
+    existingSecretPasswordKey: password
+    ## @param joplin.postgres.sslModeNoVerify Connect via POSTGRES_CONNECTION_STRING with ?sslmode=no-verify appended
+    sslModeNoVerify: false
+
+  ## Storage driver configuration
+  storage:
+    ## @param joplin.storage.driver STORAGE_DRIVER passed verbatim to Joplin Server. Examples: `Type=Database`, `Type=Filesystem; Path=/data`, `Type=S3; Region=…`
+    driver: "Type=Database"
+    ## @param joplin.storage.driverFallback [string] Optional STORAGE_DRIVER_FALLBACK value for migration scenarios
+    driverFallback: ""
+
+  ## Mailer configuration
+  mailer:
+    ## @param joplin.mailer.enabled Enable mailer support. Requires an existing Secret named by joplin.mailer.existingSecretName
+    enabled: false
+    ## @param joplin.mailer.existingSecretName Name of the Secret with mailer credentials (keys: mailerHost, mailerPort, mailerSecure, mailerAuthUser, mailerAuthPassword, mailerNoreplyName, mailerNoreplyEmail)
+    existingSecretName: joplin-mailer
+
+## @section Persistence parameters
+
+## @param persistence.enabled Enable persistent storage. Required for SQLite and Filesystem storage backends.
+## @param persistence.mountPath Mount path inside the container
+## @param persistence.storageClass [string] StorageClass for the PVC. Leave empty to use the cluster default.
+## @param persistence.accessMode PVC access mode
+## @param persistence.size PVC size
+## @param persistence.existingClaim [string] Name of an existing PVC to use instead of creating one
+persistence:
+  enabled: false
+  mountPath: /home/joplin/.config/joplin-server
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  existingClaim: ""
+
+## @section Service Account parameters
+
 serviceAccount:
-  # Specifies whether a service account should be created
+  ## @param serviceAccount.create Create a ServiceAccount for the pod
   create: true
-  # Annotations to add to the service account
+  ## @param serviceAccount.annotations [object] Annotations to add to the ServiceAccount
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  ## @param serviceAccount.name [string] Name of the ServiceAccount. Auto-generated when empty and serviceAccount.create is true.
   name: ""
 
+## @section Pod parameters
+
+## @param podAnnotations [object] Annotations to add to the pod
 podAnnotations: {}
 
+## @param podSecurityContext.fsGroup Group ID for the pod filesystem
 podSecurityContext:
   fsGroup: 1001
 
+## @param securityContext.capabilities.drop [array] Capabilities to drop from the container
+## @param securityContext.readOnlyRootFilesystem Mount the container root filesystem as read-only
+## @param securityContext.runAsNonRoot Require the container to run as a non-root user
+## @param securityContext.runAsUser User ID to run the container process
+## @param securityContext.runAsGroup Group ID to run the container process
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: false
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001
 
+## @section Service parameters
+
 service:
+  ## @param service.type Kubernetes Service type
   type: ClusterIP
+  ## @param service.port Service port
   port: 80
 
+## @section Ingress parameters
+
 ingress:
+  ## @param ingress.enabled Enable Ingress
   enabled: false
+  ## @param ingress.className IngressClass name (e.g. nginx)
   className: "nginx"
+  ## @param ingress.annotations [object] Additional annotations for the Ingress
   annotations: {}
     # kubernetes.io/tls-acme: "true"
     # cert-manager.io/cluster-issuer: letsencrypt-prod
+  ## @param ingress.hosts[0].host Hostname for the Ingress rule
+  ## @param ingress.hosts[0].paths[0].path URL path
+  ## @param ingress.hosts[0].paths[0].pathType Path type (Exact, Prefix, ImplementationSpecific)
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
+  ## @param ingress.tls [array] TLS configuration for the Ingress
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
+## @section Resource parameters
+
+## @param resources.limits.memory [default: 512Mi] Memory limit
+## @param resources.limits.cpu [default: 500m] CPU limit
+## @param resources.requests.memory [default: 256Mi] Memory request
+## @param resources.requests.cpu [default: 100m] CPU request
 resources:
   limits:
-    memory: 256Mi
-    cpu: 250m
+    memory: 512Mi
+    cpu: 500m
   requests:
     memory: 256Mi
-    cpu: 250m
+    cpu: 100m
+
+## @section Autoscaling parameters
 
 autoscaling:
+  ## @param autoscaling.enabled Enable Horizontal Pod Autoscaler
   enabled: false
+  ## @param autoscaling.minReplicas Minimum number of replicas
   minReplicas: 1
-  maxReplicas: 100
+  ## @param autoscaling.maxReplicas Maximum number of replicas
+  maxReplicas: 5
+  ## @param autoscaling.targetCPUUtilizationPercentage Target CPU utilization percentage
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+## @section Scheduling parameters
+
+## @param nodeSelector [object] Node labels for pod assignment
 nodeSelector: {}
 
+## @param tolerations [array] Tolerations for pod assignment
 tolerations: []
 
+## @param affinity [object] Affinity rules for pod assignment
 affinity: {}
-
-postgresql:
-  enabled: true
-  primary:
-    resources:
-      limits:
-        memory: 256Mi
-        cpu: 250m
-      requests:
-        memory: 256Mi
-        cpu: 250m
-    persistence:
-      size: 1Gi
-  auth:
-    # Password for the "postgres" admin user. Ignored if auth.existingSecret with key postgres-password is provided
-    postgresPassword: #ChangeMe
-    # Name for a custom user to create
-    username: joplin
-    # Password for the custom user to create. Ignored if auth.existingSecret with key password is provided
-    password: #ChangeMe
-    database: joplin-server
-    # Password for the replication user. Ignored if auth.existingSecret with key replication-password is provided
-    replicationPassword: #ChangeMe
-    # Name of existing secret to use for PostgreSQL credentials. auth.postgresPassword, auth.password, and auth.replicationPassword will be ignored and picked up from this secret. The secret might also contains the key ldap-password if LDAP is enabled. ldap.bind_password will be ignored and picked from this secret in this case.
-    existingSecret: ""


### PR DESCRIPTION
…

  Breaking changes (not upgrade-compatible with < 1.0.0):
  - Remove Bitnami PostgreSQL sub-chart; external PostgreSQL is now required when using joplin.database.client=pg
  - Restructure values keys (joplin.APP_PORT → joplin.appPort, etc.)

  New features:
  - Add SQLite backend support (joplin.database.client=sqlite, default)
  - Add STORAGE_DRIVER / STORAGE_DRIVER_FALLBACK configuration (Database, Filesystem, S3)
  - Add PVC support for SQLite and Filesystem storage (persistence.*)
  - Add postgres.existingSecret for Secret-based credential injection
  - Add values.schema.json for Helm schema validation

  Fixes:
  - containerPort now uses joplin.appPort instead of hardcoded 22300
  - Fix mailerport → mailerPort secret key casing (was causing runtime failures)
  - Fix POSTGRES_PASSWORD ordering before POSTGRES_CONNECTION_STRING
  - Enable liveness/readiness probes on /api/ping
  - Upgrade HPA to autoscaling/v2; declare kubeVersion >=1.23.0-0
  - Simplify Ingress to networking.k8s.io/v1 only; drop pre-1.19 branches
  - Reduce HPA maxReplicas default from 100 to 5
  - Bump appVersion to 3.6.1

  Docs:
  - Annotate values.yaml for readme-generator-for-helm
  - Regenerate README Parameters table
  - Add breaking-change notice to NOTES.txt and README

Changelog: other